### PR TITLE
Move the graphite connection after we receive metrics on the metricsC…

### DIFF
--- a/es-stats.go
+++ b/es-stats.go
@@ -99,20 +99,20 @@ func pollEs(nodeName string) {
 
 func handleMetrics() {
 	for {
-		// Connect to Graphite.
-		graphite, err := net.Dial("tcp", graphiteIp+":"+graphitePort)
-		if err != nil {
-			log.Printf("Graphite unreachable: %s", err)
-			time.Sleep(30 * time.Second)
-			continue
-		}
-
 		// Ship metrics.
 		metrics := <-metricsChan
 		log.Println("Metrics received")
 
 		ts := metrics["timestamp"]
 		delete(metrics, "timestamp")
+
+                // Connect to Graphite.
+		graphite, err := net.Dial("tcp", graphiteIp+":"+graphitePort)
+		if err != nil {
+			log.Printf("Graphite unreachable: %s", err)
+			time.Sleep(30 * time.Second)
+			continue
+		}
 
 		for k, v := range metrics {
 			_, err := fmt.Fprintf(graphite, "%s.%s %d %d\n", metricsPrefix, k, v, ts)


### PR DESCRIPTION
…han channel. We can perhaps avoid the unneeded wait with the open tcp connction which I think results in the occasional 'broken pipe' errors.